### PR TITLE
Bug(Gradle configuration) - Add jwplayer maven repo 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    lintOptions {
+        abortOnError false
+    }
+
+    publishNonDefault true
 }
 
 repositories {


### PR DESCRIPTION
## Description:
In build.gradle the jwplayer dependencies need refernce to jwplayer maven repo.

### Checklist for this pull request
- [x] PR is scoped to one task
- [ ] Tests included

- One of:
  - [ ] The PR is not making any UI change
  - [ ] The PR is making a UI change
    - [ ] Screenshots included

Thank you!
