### PR TITLE
Enable prehooks in the player

### DIFF
--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -12,16 +12,17 @@
     }
   ],
   "platform": "android",
-  "author_name": "Hanny Peleg",
-  "author_email": "h.peleg@applicaster.com",
-  "manifest_version": "1.3.5",
+  "author_name": "Pablo Rueda",
+  "author_email": "p.rueda@applicaster.com",
+  "manifest_version": "1.4.0",
   "name": "JW Player",
   "description": "Android plugin for JWPlayer",
   "type": "player",
+  "screen": true,
   "identifier": "JWPlayer-Plugin",
   "ui_builder_support": true,
   "dependency_name": "com.applicaster:JWPlayerPlugin",
-  "dependency_version": "1.3.5",
+  "dependency_version": "1.4.0",
   "whitelisted_account_ids": [],
   "min_zapp_sdk": "4.3.12-dev",
   "react_native": false,
@@ -66,5 +67,21 @@
       "key": "vod_ad_type",
       "tooltip_text": "VOD Ad Type"
     }
-  ]
+  ],
+  "hooks": {
+    "fields": [
+      {
+        "group": true,
+        "label": "Before Load",
+        "folded": true,
+        "fields": [
+          {
+            "key": "preload_plugins",
+            "type": "preload_plugins_selector",
+            "label": "Select Plugins"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -66,6 +66,11 @@
       "type": "text",
       "key": "vod_ad_type",
       "tooltip_text": "VOD Ad Type"
+    },
+    {
+      "type": "checkbox",
+      "key": "ignore_default_subscription",
+      "default": 0
     }
   ],
   "hooks": {

--- a/src/main/java/com/applicaster/jwplayerplugin/JWPlayerAdapter.java
+++ b/src/main/java/com/applicaster/jwplayerplugin/JWPlayerAdapter.java
@@ -3,6 +3,7 @@ package com.applicaster.jwplayerplugin;
 import android.app.Activity;
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
 import android.util.Log;
 import android.view.ViewGroup;
 
@@ -13,15 +14,19 @@ import com.applicaster.plugin_manager.login.LoginContract;
 import com.applicaster.plugin_manager.login.LoginManager;
 import com.applicaster.plugin_manager.playersmanager.Playable;
 import com.applicaster.plugin_manager.playersmanager.PlayableConfiguration;
+import com.applicaster.plugin_manager.screen.PluginScreen;
 import com.longtailvideo.jwplayer.JWPlayerView;
 import com.longtailvideo.jwplayer.core.PlayerState;
 import com.longtailvideo.jwplayer.events.FullscreenEvent;
 import com.longtailvideo.jwplayer.events.listeners.VideoPlayerEvents;
 import com.longtailvideo.jwplayer.fullscreen.FullscreenHandler;
+
+import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class JWPlayerAdapter extends BasePlayer implements FullscreenHandler, VideoPlayerEvents.OnFullscreenListener {
+public class JWPlayerAdapter extends BasePlayer implements FullscreenHandler, VideoPlayerEvents.OnFullscreenListener, PluginScreen {
 
     public static final String TAG = "JWPLAYER_DEBUG_KEY";
     private static final String LICENSE_KEY = "LICENSE_KEY";
@@ -271,6 +276,20 @@ public class JWPlayerAdapter extends BasePlayer implements FullscreenHandler, Vi
             displayVideo(false);
         }
     }
+
+    //region PluginScreen
+
+    //Necessary to implement this method to allow prehooks, however this constructor is never called for a player
+    @Override
+    public void present(Context context, HashMap<String, Object> screenMap, Serializable dataSource, boolean isActivity) { }
+
+    @Override
+    public Fragment generateFragment(HashMap<String, Object> screenMap, Serializable dataSource) {
+        return null;
+    }
+
+    //endregion
+
 
     /************************** PlayerLoaderI ********************/
     private class ApplicaterPlayerLoaderListener implements PlayerLoaderI {


### PR DESCRIPTION
For a player to have prehooks configured, it needs to be implementing the PluginScreen  interface, this is because to configure the hooks you need to add it as a screen in uibuilder (even if the player will not be used as a screen).

Android version of https://github.com/applicaster/JWPlayer-Plugin-iOS/pull/13