### PR TITLE
Modified proguard rules to not to obfuscate protected methods

### DIFF
--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -7,6 +7,7 @@
 -keep public class com.applicaster.jwplayerplugin.JWPlayerAdapter {
    public <fields>;
    public <methods>;
+   protected <methods>;
 }
 -keep public class com.applicaster.jwplayerplugin.JWPlayerContainer {
    public <fields>;


### PR DESCRIPTION
Modified proguard rules to not to obfuscate protected methods to be able to inherit JWPlayerAdapter in wrapper.