### PR TITLE
Pom file exclusions were unsuccessful

### DIFF
--- a/bintray_publisher.gradle
+++ b/bintray_publisher.gradle
@@ -71,9 +71,10 @@ publishing {
                             dependencyNode.appendNode('groupId', it.group)
                             dependencyNode.appendNode('artifactId', it.name)
                             dependencyNode.appendNode('version', it.version)
-                            if (it.name.is('jwplayer-common') || it.name.is('jwplayer-ima')) {
-                                def exclusionsNode = dependencyNode.appendNode('exclusions')
-                                def exclusionNode = exclusionsNode.appendNode('exclusion')
+
+                            // Exclude Google libraries in the pom file
+                            if ((it.name == 'jwplayer-common') || (it.name == 'jwplayer-ima')) {
+                                def exclusionNode = dependencyNode.appendNode('exclusions').appendNode('exclusion')
                                 exclusionNode.appendNode('groupId', 'com.google.android.gms')
                                 exclusionNode.appendNode('artifactId', 'play-services-ads-identifier')
                             }


### PR DESCRIPTION
The exclusions were unsuccessful. If anybody wants to build an app with the latest version of the binary, the build will fail. This should fix it, attempting to create a binary from this branch.