### PR TITLE
fix: destroy the view when detach from window

### DIFF
--- a/src/main/java/com/applicaster/jwplayerplugin/JWPlayerContainer.java
+++ b/src/main/java/com/applicaster/jwplayerplugin/JWPlayerContainer.java
@@ -85,6 +85,8 @@ public class JWPlayerContainer extends FrameLayout{
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         // onDestroy() called
+        if(jwPlayerView != null)
+            jwPlayerView.onDestroy();
     }
 
     @Override


### PR DESCRIPTION
The issue: 
The audio kept playing in the background when swiped out the screen and the player is no longer presented to the user. 

The context is still alive so we need to call the on destroy manually.

https://applicaster.atlassian.net/browse/MS5-33